### PR TITLE
spiral/1.0.0-beta.3

### DIFF
--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5222",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7265;http://localhost:5222",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}


### PR DESCRIPTION
These updates will need to go in place when v1.0.0-beta.3 is released.

- I removed the -now unnecessary- code that passes in JsonSerializerOptions (as that is done now)
- Headers aren't part of the ServerSentEventHttpHandlers constructor
- I moved the StartResponse code out of the ServerSentEventHttpHandlers constructor. It has to be called explicitly, if you are rolling your own.